### PR TITLE
Support for namespaced XPath queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "xml"
   ],
   "dependencies": {
-    "xpath": "0.0.5",
+    "xpath": "0.0.6",
     "xmldom": "~0.1.16",
     "lodash": "2.4.1"
   }

--- a/tasks/xmlpoke.js
+++ b/tasks/xmlpoke.js
@@ -47,7 +47,8 @@ module.exports = function (grunt) {
                 var queries = typeof replacement.xpath === 'string' ? [replacement.xpath] : replacement.xpath,
                     getValue = _.isFunction(replacement.value) ? replacement.value : function () { return replacement.value || ''; };
                 queries.forEach(function (query) {
-                    var nodes = xpath.select(query, doc);
+                    var select = options.namespaces ? xpath.useNamespaces(options.namespaces) : xpath.select;
+                    var nodes = select(query, doc);
                     nodes.forEach(function (node) {
                         var value = getValue(node);
                         grunt.verbose.writeln('setting value of "' + query + '" to "' + value + '"');


### PR DESCRIPTION
Allows the user to supply a `namespaces` option. `namespaces` must be an object of identifier => namespace key/value pairs, in the same format expected by [xpath.useNamespaces](https://www.npmjs.org/package/xpath#namespaces-with-easy-mappings). The `namespaces` value is then passed directly to [xpath.useNamespaces](https://www.npmjs.org/package/xpath#namespaces-with-easy-mappings).

This allows xmlpoke to perform xpath queries on XML documents with namespaces.  

xpath version was upgraded from v0.0.5 to v0.0.6, which provides the [useNamespaces](https://www.npmjs.org/package/xpath#namespaces-with-easy-mappings) method.

Example usage:
XML Document:

```
<?xml version="1.0"?>
<RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.mozilla.org/2004/em-rdf#">
    <Description about="urn:mozilla:install-manifest">
        <em:version>1.2.3</em:version>
    </Description>
</RDF>
```

Gruntfile.js

```
    xmlpoke: {
      updateFirefoxVersion: {
        dest: 'destination.xml',
        src: 'source.xml',
        options: {
          namespaces: {
            'em': 'http://www.mozilla.org/2004/em-rdf#'
          },
          xpath: '/RDF/Description/em:version',
          value: '1.2.4'
        }
      }
    }
```
