### PR TITLE
Add support for appending nodes by setting valueType to append.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,6 +67,22 @@ module.exports = function (grunt) {
                     'tmp/testing_element.xml': 'test/fixtures/testing.xml'
                 }
             },
+            testing_element_append: {
+                options: {
+                    replacements: [{
+                        xpath: '/data',
+                        value: '<child>UPDATED information</child>',
+                        valueType: 'element'
+                    }, {
+                        xpath: '/data',
+                        value: '<child>UPDATED information appended</child>',
+                        valueType: 'append'
+                    }]
+                },
+                files: {
+                    'tmp/testing_element_append.xml': 'test/fixtures/testing.xml'
+                }
+            },
             testing_element_without: {
                 options: {
                     xpath: '/data/without',

--- a/tasks/xmlpoke.js
+++ b/tasks/xmlpoke.js
@@ -60,6 +60,9 @@ module.exports = function (grunt) {
                             }
                             node.appendChild(domParser.parseFromString(value));
                         }
+                        else if (valueType === 'append') {
+                            node.appendChild(domParser.parseFromString(value));
+                        }
                         else if (valueType === 'remove') {
                             var parentNode = node.parentNode;
                             parentNode.removeChild(node);

--- a/test/expected/testing_element_append.xml
+++ b/test/expected/testing_element_append.xml
@@ -1,0 +1,1 @@
+<data test-value="Test"><child>UPDATED information</child><child>UPDATED information appended</child></data>

--- a/test/xmlpoke_test.js
+++ b/test/xmlpoke_test.js
@@ -63,6 +63,15 @@ exports.xmlpoke = {
 
         test.done();
     },
+    testing_element_append: function (test) {
+        test.expect(1);
+
+        var actual = grunt.file.read('tmp/testing_element_append.xml'),
+            expected = grunt.file.read('test/expected/testing_element_append.xml');
+        test.equal(actual, expected, 'should append new XML node without affected existing child nodes.');
+
+        test.done();
+    },
     testing_element_without : function(test){
         test.expect(1);
 


### PR DESCRIPTION
The "append" valueType allows the ability to append an node to a parent, without first removing all the parent's children.  A new test has been added and the script is passing.
