### PR TITLE
Lock xmldom dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "xpath": "0.0.6",
-    "xmldom": "~0.1.16",
+    "xmldom": "0.1.19",
     "lodash": "2.4.1"
   }
 }


### PR DESCRIPTION
Breaking change in xmldom 0.1.20, so I think locking the version number to 0.1.19 for now is a good idea. 

See
issue: https://github.com/jindw/xmldom/issues/146
and pull request: https://github.com/jindw/xmldom/pull/148
